### PR TITLE
Use deepgram crate from Crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,8 +96,9 @@ dependencies = [
 
 [[package]]
 name = "deepgram"
-version = "0.2.0-alpha.3"
-source = "git+https://www.github.com/deepgram-devs/deepgram-rust-sdk?branch=all-mods#b25cbce36e100e9a524a9afac26347a9560e99e8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7fcecaeb6cb0c9ee8bd4c1f0e67eba98994235a34c7c62d9906afb67c6226a7"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-deepgram = {git = "https://www.github.com/deepgram-devs/deepgram-rust-sdk", branch = "all-mods"}
+deepgram = "0.2"
 reqwest = {version = "0.11.7", features = ["json"]}
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ mod srt;
 use crate::srt::{CreateSubtitles, Subtitles};
 use deepgram::{
     transcription::prerecorded::{
-        audio_source::BufferSource,
+        audio_source::AudioSource,
         options::{Language, Options},
     },
     Deepgram, DeepgramError,
@@ -23,10 +23,7 @@ async fn main() -> Result<(), DeepgramError> {
 
     let file = File::open(PATH_TO_FILE).await.unwrap();
 
-    let source = BufferSource {
-        buffer: file,
-        mimetype: Some("audio/mpeg3"),
-    };
+    let source = AudioSource::from_buffer_with_mime_type(file, "audio/mpeg3");
 
     let options = Options::builder()
         .punctuate(true)


### PR DESCRIPTION
The features that you have been using from the Deepgram Rust SDK have been published to [Crates.io](https://crates.io/), so it's no longer necessary to specify it as a Git dependency.